### PR TITLE
implement google maps nearby automotive shops functionality

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -42,6 +42,13 @@ android {
             "NEWS_API_KEY",
             "\"${localProperties.getProperty("NEWS_API_KEY", "")}\""
         )
+        buildConfigField(
+            "String",
+            "GOOGLE_MAPS_API_KEY",
+            "\"${localProperties.getProperty("GOOGLE_MAPS_API_KEY", "")}\""
+        )
+        
+        manifestPlaceholders["GOOGLE_MAPS_API_KEY"] = localProperties.getProperty("GOOGLE_MAPS_API_KEY", "")
     }
 
     buildTypes {
@@ -111,5 +118,10 @@ dependencies {
     implementation("io.ktor:ktor-client-cio:${libs.versions.ktor.get()}")
     implementation("io.ktor:ktor-client-content-negotiation:${libs.versions.ktor.get()}")
     implementation("io.ktor:ktor-serialization-kotlinx-json:${libs.versions.ktor.get()}")
+    
+    // Google Maps and Places
+    implementation("com.google.android.gms:play-services-maps:18.2.0")
+    implementation("com.google.android.gms:play-services-location:21.0.1")
+    implementation("com.google.android.libraries.places:places:3.3.0")
 
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -3,6 +3,8 @@
     xmlns:tools="http://schemas.android.com/tools">
 
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
 
     <application
         android:allowBackup="true"
@@ -13,6 +15,11 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/Theme.ModMyCar">
+        
+        <meta-data
+            android:name="com.google.android.geo.API_KEY"
+            android:value="${GOOGLE_MAPS_API_KEY}" />
+        
         <activity
             android:name=".MainActivity"
             android:exported="true">

--- a/app/src/main/java/com/example/modmycar/PlaceholderScreens.kt
+++ b/app/src/main/java/com/example/modmycar/PlaceholderScreens.kt
@@ -6,11 +6,7 @@ class PopularBuildsActivity : SimplePlaceholderActivity() {
         "This screen will highlight trending builds curated from the community."
 }
 
-class NearbyShopsActivity : SimplePlaceholderActivity() {
-    override val screenTitle: String = "Nearby Shops"
-    override val descriptionText: String =
-        "A map of nearby tuning or parts shops will appear here."
-}
+// NearbyShopsActivity has been moved to its own file with full implementation
 
 class FriendsListActivity : SimplePlaceholderActivity() {
     override val screenTitle: String = "Friends List"


### PR DESCRIPTION
summary:
Add google maps and places api to show nearby automotive shops (repair, tuning, parts) around the user

Features:
- Interactive map with user location
- Auto-discovery of shops within 5km
- Shop info card: name, address, distance, rating, hours, phone, website
- Strict filtering for relevant automotive businesses
- Clean Material UI with loading states, shop count badge, improved markers

Files
- Added: Shop.kt, PlacesRepository.kt, map layout
- Updated: manifest, gradle, NearbyShopsActivity

Note:
Add GOOGLE_MAPS_API_KEY in local.properties